### PR TITLE
Wrap member token endpoints in response entities

### DIFF
--- a/auth-service/src/main/java/com/adventuretube/auth/service/AuthService.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/service/AuthService.java
@@ -238,17 +238,26 @@ public class AuthService {
         String token = TokenSanitizer.sanitize(httpServletRequest.getHeader("Authorization")); // Assuming the token is passed in the Authorization header
         //using access token for logout
         String urlForDeleteToken = "http://MEMBER-SERVICE/member/deleteAllToken";
-        Boolean isLoggedOut = restTemplate.postForObject(urlForDeleteToken, token, Boolean.class);
-        if (!isLoggedOut) {
+        ResponseEntity<ServiceResponse<Boolean>> deleteTokenResponse = restTemplate.exchange(
+                urlForDeleteToken,
+                org.springframework.http.HttpMethod.POST,
+                new HttpEntity<>(token),
+                new ParameterizedTypeReference<ServiceResponse<Boolean>>() {}
+        );
+        ServiceResponse<Boolean> deleteTokenResponseBody = deleteTokenResponse.getBody();
+        if (!deleteTokenResponse.getStatusCode().is2xxSuccessful()
+                || deleteTokenResponseBody == null
+                || !deleteTokenResponseBody.isSuccess()
+                || !Boolean.TRUE.equals(deleteTokenResponseBody.getData())) {
             throw new TokenDeletionException(AuthErrorCode.TOKEN_DELETION_FAILED);
-        } else {
-            logger.info("Token revoked successfully for token: {}", token);
-            return ServiceResponse.builder()
-                    .success(true)
-                    .message("Logout has been successful")
-                    .data(isLoggedOut)
-                    .build();
         }
+
+        logger.info("Token revoked successfully for token: {}", token);
+        return ServiceResponse.builder()
+                .success(true)
+                .message("Logout has been successful")
+                .data(deleteTokenResponseBody.getData())
+                .build();
 
 
     }
@@ -267,8 +276,17 @@ public class AuthService {
 
         //check the token for logout
         String urlForTokenExist = "http://MEMBER-SERVICE/member/findToken";
-        Boolean isTokenFind = restTemplate.postForObject(urlForTokenExist, token, Boolean.class);
-        if (!isTokenFind) {
+        ResponseEntity<ServiceResponse<Boolean>> findTokenResponse = restTemplate.exchange(
+                urlForTokenExist,
+                org.springframework.http.HttpMethod.POST,
+                new HttpEntity<>(token),
+                new ParameterizedTypeReference<ServiceResponse<Boolean>>() {}
+        );
+        ServiceResponse<Boolean> findTokenResponseBody = findTokenResponse.getBody();
+        if (!findTokenResponse.getStatusCode().is2xxSuccessful()
+                || findTokenResponseBody == null
+                || !findTokenResponseBody.isSuccess()
+                || !Boolean.TRUE.equals(findTokenResponseBody.getData())) {
             throw new TokenNotFoundException(AuthErrorCode.TOKEN_NOT_FOUND);
         }
 

--- a/member-service/src/main/java/com/adventuretube/member/controller/MemberController.java
+++ b/member-service/src/main/java/com/adventuretube/member/controller/MemberController.java
@@ -80,13 +80,26 @@ public class MemberController {
     }
 
     @PostMapping("findToken")
-    public Boolean findToken(@RequestBody String token) {
-        return memberService.findToken(token).isPresent();
+    public ResponseEntity<ServiceResponse<Boolean>> findToken(@RequestBody String token) {
+        boolean exists = memberService.findToken(token).isPresent();
+        return ResponseEntity.ok(ServiceResponse.<Boolean>builder()
+                .success(true)
+                .message(exists ? "Token found" : "Token not found")
+                .data(exists)
+                .build());
     }
 
     @PostMapping("deleteAllToken")
-    public Boolean deleteAllToken(@RequestBody String token) {
-        return memberService.deleteAllToken(token);
+    public ResponseEntity<ServiceResponse<Boolean>> deleteAllToken(@RequestBody String token) {
+        boolean deleted = memberService.deleteAllToken(token);
+        HttpStatus status = deleted ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+        String message = deleted ? "Token deleted successfully" : "Token not found";
+        return ResponseEntity.status(status)
+                .body(ServiceResponse.<Boolean>builder()
+                        .success(deleted)
+                        .message(message)
+                        .data(deleted)
+                        .build());
     }
 
     @PostMapping("deleteUser")


### PR DESCRIPTION
## Summary
- return ResponseEntity from `findToken` and `deleteAllToken` in `MemberController`
- update `AuthService` to parse `ServiceResponse` when invoking member token endpoints

## Testing
- `mvn -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684ac97bc224832cae5c01f881552bee