### PR TITLE
Add timestamp to ServiceResponse

### DIFF
--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/global/GlobalExceptionHandler.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/global/GlobalExceptionHandler.java
@@ -40,6 +40,7 @@ public class GlobalExceptionHandler {
                 .message(AuthErrorCode.VALIDATION_FAILED.getMessage())
                 .errorCode(AuthErrorCode.VALIDATION_FAILED.name())
                 .data(errors)
+                .timestamp(java.time.LocalDateTime.now())
                 .build();
 
         return new ResponseEntity<>(response, AuthErrorCode.VALIDATION_FAILED.getHttpStatus());
@@ -55,6 +56,7 @@ public class GlobalExceptionHandler {
                         .message(errorCode.getMessage())
                         .errorCode(errorCode.name())
                         .data(null)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build(),
                 errorCode.getHttpStatus()
         );
@@ -67,6 +69,7 @@ public class GlobalExceptionHandler {
                         .message(errorCode.getMessage())
                         .errorCode(errorCode.name())
                         .data(ex.getOrigin() + " : auth-service")
+                        .timestamp(java.time.LocalDateTime.now())
                         .build(),
                 errorCode.getHttpStatus()
         );

--- a/auth-service/src/main/java/com/adventuretube/auth/service/AuthService.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/service/AuthService.java
@@ -257,6 +257,7 @@ public class AuthService {
                 .success(true)
                 .message("Logout has been successful")
                 .data(deleteTokenResponseBody.getData())
+                .timestamp(java.time.LocalDateTime.now())
                 .build();
 
 

--- a/common-api/src/main/java/com/adventuretube/common/api/response/ServiceResponse.java
+++ b/common-api/src/main/java/com/adventuretube/common/api/response/ServiceResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -14,4 +15,5 @@ public class ServiceResponse<T> {
     private String message;
     private String errorCode;
     private T data;
+    private LocalDateTime timestamp;
 }

--- a/gateway-service/src/main/java/com/adventuretube/apigateway/exception/GlobalExceptionHandler.java
+++ b/gateway-service/src/main/java/com/adventuretube/apigateway/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ public class GlobalExceptionHandler {
                         .message(ex.getMessage())
                         .errorCode("JWT_TOKEN_NOT_EXIST : gateway-service")
                         .data(null)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
     }
 
@@ -36,6 +37,7 @@ public class GlobalExceptionHandler {
                         .message("Invalid JWT signature: gateway-service")
                         .errorCode(ex.getMessage())
                         .data(null)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
     }
 
@@ -48,6 +50,7 @@ public class GlobalExceptionHandler {
                         .message("Malformed JWT token: gateway-service")
                         .errorCode(ex.getMessage())
                         .data(null)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
     }
 
@@ -60,6 +63,7 @@ public class GlobalExceptionHandler {
                         .message("Expired JWT token: gateway-service")
                         .errorCode(ex.getMessage())
                         .data(null)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
     }
 
@@ -72,6 +76,7 @@ public class GlobalExceptionHandler {
                         .message("Internal Server Error: gateway-service")
                         .errorCode(ex.getMessage())
                         .data(null)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
     }
 }

--- a/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/GlobalExceptionHandler.java
+++ b/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.adventuretube.geospatial.exceptions;
 
 import com.adventuretube.common.api.response.ServiceResponse;
+import com.adventuretube.geospatial.exceptions.code.GeoErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -16,9 +17,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ServiceResponse<?>> handleUnknownException(Exception ex) {
         ServiceResponse<?> response = ServiceResponse.builder()
                 .success(false)
-                .message("Internal Server Error: geospatial-service")
-                .errorCode(ex.getMessage())
+                .message(GeoErrorCode.UNKNOWN_EXCEPTION.getMessage() + ": geospatial-service")
+                .errorCode(GeoErrorCode.UNKNOWN_EXCEPTION.name())
                 .data(null)
+                .timestamp(java.time.LocalDateTime.now())
                 .build();
 
         return ResponseEntity.status(INTERNAL_SERVER_ERROR).body(response);
@@ -28,9 +30,10 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ServiceResponse<?>> handleUsernameNotFoundException(UsernameNotFoundException ex) {
         ServiceResponse<?> response = ServiceResponse.builder()
                 .success(false)
-                .message("User does not exist: geospatial-service")
-                .errorCode(ex.getMessage())
+                .message(GeoErrorCode.USER_NOT_FOUND.getMessage() + ": geospatial-service")
+                .errorCode(GeoErrorCode.USER_NOT_FOUND.name())
                 .data(null)
+                .timestamp(java.time.LocalDateTime.now())
                 .build();
 
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);

--- a/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/code/GeoErrorCode.java
+++ b/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/code/GeoErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum GeoErrorCode {
     ENV_FILE_NOT_FOUND("ENV_FILE_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    USER_NOT_FOUND("User not found", HttpStatus.NOT_FOUND),
+
     //UNKNOWN EXCEPTION
     UNKNOWN_EXCEPTION("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
     private final String message;

--- a/member-service/src/main/java/com/adventuretube/member/controller/MemberController.java
+++ b/member-service/src/main/java/com/adventuretube/member/controller/MemberController.java
@@ -35,6 +35,7 @@ public class MemberController {
                     .success(true)
                     .message("Member registered successfully")
                     .data(memberDTO)
+                    .timestamp(java.time.LocalDateTime.now())
                     .build());
 
         } catch (Exception e) {
@@ -45,6 +46,7 @@ public class MemberController {
                             .message("Failed to register member")
                             .errorCode("MEMBER_REGISTRATION_FAILED")
                             .data(null)
+                            .timestamp(java.time.LocalDateTime.now())
                             .build());
         }
     }
@@ -56,6 +58,7 @@ public class MemberController {
                 .success(true)
                 .message(member.isPresent() ? "Email already exists" : "Email is available")
                 .data(member.isPresent())
+                .timestamp(java.time.LocalDateTime.now())
                 .build());
     }
 
@@ -66,6 +69,7 @@ public class MemberController {
                 .success(true)
                 .message(member.isPresent() ? "Member found" : "Member not found")
                 .data(member.map(memberMapper::memberToMemberDTO).orElse(null))
+                .timestamp(java.time.LocalDateTime.now())
                 .build());
     }
 
@@ -76,6 +80,7 @@ public class MemberController {
                 .success(true)
                 .message("Token stored successfully")
                 .data(result)
+                .timestamp(java.time.LocalDateTime.now())
                 .build());
     }
 
@@ -86,6 +91,7 @@ public class MemberController {
                 .success(true)
                 .message(exists ? "Token found" : "Token not found")
                 .data(exists)
+                .timestamp(java.time.LocalDateTime.now())
                 .build());
     }
 
@@ -99,6 +105,7 @@ public class MemberController {
                         .success(deleted)
                         .message(message)
                         .data(deleted)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
     }
 
@@ -112,12 +119,14 @@ public class MemberController {
                         .success(true)
                         .message("User deleted successfully")
                         .data(true)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
             } else {
                 return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ServiceResponse.<Boolean>builder()
                         .success(false)
                         .message("User not found")
                         .data(false)
+                        .timestamp(java.time.LocalDateTime.now())
                         .build());
             }
         } catch (Exception e) {
@@ -127,6 +136,7 @@ public class MemberController {
                     .message("Error occurred while deleting user")
                     .errorCode("DELETE_USER_ERROR")
                     .data(null)
+                    .timestamp(java.time.LocalDateTime.now())
                     .build());
         }
     }

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/GlobalExceptionHandler.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ public class GlobalExceptionHandler {
                 .message("User already exists with the provided email : member-service")
                 .errorCode("DUPLICATE_ERROR")
                 .data(null)
+                .timestamp(java.time.LocalDateTime.now())
                 .build();
 
         return new ResponseEntity<ServiceResponse<Void>>(restAPIErrorResponse,HttpStatus.CONFLICT);
@@ -34,6 +35,7 @@ public class GlobalExceptionHandler {
                 .message("Internal Server Error : member-service")
                 .errorCode("UNKNOWN_ERROR")
                 .data(null)
+                .timestamp(java.time.LocalDateTime.now())
                 .build();
 
             return new ResponseEntity<>(restAPIErrorResponse, INTERNAL_SERVER_ERROR);


### PR DESCRIPTION
## Summary
- extend `ServiceResponse` with a `timestamp` field
- include the timestamp in all response builders
- standardize geospatial error responses

## Testing
- `mvn -q -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684add3a9bbc832cb4f4d914dec0d838