### PR TITLE
Introduce shared error code enums

### DIFF
--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/AccessDeniedException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/AccessDeniedException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class AccessDeniedException extends BaseServiceException {
-    public AccessDeniedException(AuthErrorCode errorCode) {
+    public AccessDeniedException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/DuplicateException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/DuplicateException.java
@@ -1,11 +1,11 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class DuplicateException extends BaseServiceException {
 
-    public DuplicateException(AuthErrorCode errorCode) {
+    public DuplicateException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/GoogleIdTokenInvalidException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/GoogleIdTokenInvalidException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class GoogleIdTokenInvalidException extends BaseServiceException {
-    public GoogleIdTokenInvalidException(AuthErrorCode errorCode) {
+    public GoogleIdTokenInvalidException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/InternalServerException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/InternalServerException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class InternalServerException extends BaseServiceException {
-    public InternalServerException(AuthErrorCode errorCode) {
+    public InternalServerException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/MemberServiceException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/MemberServiceException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class MemberServiceException extends BaseServiceException {
-    public MemberServiceException(AuthErrorCode errorCode) {
+    public MemberServiceException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenDeletionException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenDeletionException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class TokenDeletionException extends BaseServiceException {
-    public TokenDeletionException(AuthErrorCode errorCode) {
+    public TokenDeletionException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenExpiredException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenExpiredException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class TokenExpiredException extends BaseServiceException {
-    public TokenExpiredException(AuthErrorCode errorCode) {
+    public TokenExpiredException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenNotFoundException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenNotFoundException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class TokenNotFoundException extends BaseServiceException {
-    public TokenNotFoundException(AuthErrorCode errorCode) {
+    public TokenNotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenSaveFailedException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/TokenSaveFailedException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class TokenSaveFailedException extends BaseServiceException {
-    public TokenSaveFailedException(AuthErrorCode errorCode) {
+    public TokenSaveFailedException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/UnKnownException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/UnKnownException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class UnKnownException  extends BaseServiceException {
-    public UnKnownException(AuthErrorCode errorCode) {
+    public UnKnownException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/UserNotFoundException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/UserNotFoundException.java
@@ -1,10 +1,10 @@
 package com.adventuretube.auth.exceptions;
 
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class UserNotFoundException extends BaseServiceException {
-    public UserNotFoundException(AuthErrorCode errorCode) {
+    public UserNotFoundException(ErrorCode errorCode) {
         super(errorCode);
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/base/BaseServiceException.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/base/BaseServiceException.java
@@ -1,12 +1,12 @@
 package com.adventuretube.auth.exceptions.base;
 
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public abstract class BaseServiceException extends RuntimeException {
-    private final AuthErrorCode errorCode;
+    private final ErrorCode errorCode;
     private final String origin;
 
-    public BaseServiceException(AuthErrorCode errorCode) {
+    public BaseServiceException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
 
@@ -17,7 +17,7 @@ public abstract class BaseServiceException extends RuntimeException {
                 : "UnknownOrigin";
     }
 
-    public AuthErrorCode getErrorCode() {
+    public ErrorCode getErrorCode() {
         return errorCode;
     }
 

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/code/AuthErrorCode.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/code/AuthErrorCode.java
@@ -1,10 +1,11 @@
 package com.adventuretube.auth.exceptions.code;
 
+import com.adventuretube.common.api.code.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum AuthErrorCode {
+public enum AuthErrorCode implements ErrorCode {
     //Google Exceptions
     GOOGLE_TOKEN_INVALID("Google ID token is not valid", HttpStatus.UNAUTHORIZED),
     GOOGLE_TOKEN_MALFORMED("Google ID token is malformed ", HttpStatus.UNAUTHORIZED),
@@ -12,27 +13,15 @@ public enum AuthErrorCode {
 
     //User Exceptions
     USER_EMAIL_DUPLICATE("User already exists with the provided email", HttpStatus.CONFLICT),
-    USER_NOT_FOUND("User not found", HttpStatus.NOT_FOUND),
     USER_CREDENTIALS_INVALID("Invalid username or password", HttpStatus.UNAUTHORIZED),
 
 
     //System Exceptions
-    SERVER_NOT_AVAILABLE("Server is not available", HttpStatus.INTERNAL_SERVER_ERROR),
-    INTERNAL_ERROR("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR),
-    VALIDATION_FAILED("Validation failed", HttpStatus.BAD_REQUEST),
     USER_DOES_NOT_EXIST("User does not exist", HttpStatus.NOT_FOUND),
 
     //JWT Exceptions
-    TOKEN_DELETION_FAILED("Failed to delete token during logout", HttpStatus.INTERNAL_SERVER_ERROR),
-    TOKEN_SAVE_FAILED("Failed to save token during login", HttpStatus.INTERNAL_SERVER_ERROR),
-    TOKEN_NOT_FOUND("Token not found", HttpStatus.NOT_FOUND),
-    TOKEN_EXPIRED("Token expired", HttpStatus.UNAUTHORIZED),
     //Member Service Exceptions
-    MEMBER_REGISTRATION_FAILED("Failed to register member", HttpStatus.INTERNAL_SERVER_ERROR),
-    
-    
-    //UNKNOWN EXCEPTION
-    UNKNOWN_EXCEPTION("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
+    MEMBER_REGISTRATION_FAILED("Failed to register member", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus httpStatus;

--- a/auth-service/src/main/java/com/adventuretube/auth/exceptions/global/GlobalExceptionHandler.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/exceptions/global/GlobalExceptionHandler.java
@@ -3,6 +3,9 @@ package com.adventuretube.auth.exceptions.global;
 import com.adventuretube.auth.exceptions.*;
 import com.adventuretube.auth.exceptions.base.BaseServiceException;
 import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
+import com.adventuretube.common.api.code.JwtErrorCode;
+import com.adventuretube.common.api.code.SystemErrorCode;
 import com.adventuretube.common.api.response.ServiceResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -37,19 +40,19 @@ public class GlobalExceptionHandler {
 
         ServiceResponse<?> response = ServiceResponse.builder()
                 .success(false)
-                .message(AuthErrorCode.VALIDATION_FAILED.getMessage())
-                .errorCode(AuthErrorCode.VALIDATION_FAILED.name())
+                .message(SystemErrorCode.VALIDATION_FAILED.getMessage())
+                .errorCode(SystemErrorCode.VALIDATION_FAILED.name())
                 .data(errors)
                 .timestamp(java.time.LocalDateTime.now())
                 .build();
 
-        return new ResponseEntity<>(response, AuthErrorCode.VALIDATION_FAILED.getHttpStatus());
+        return new ResponseEntity<>(response, SystemErrorCode.VALIDATION_FAILED.getHttpStatus());
     }
 
     // ---------------------------
     // Helper Methods
     // ---------------------------
-    private ResponseEntity<ServiceResponse<?>> buildErrorResponse(AuthErrorCode errorCode) {
+    private ResponseEntity<ServiceResponse<?>> buildErrorResponse(ErrorCode errorCode) {
         return new ResponseEntity<>(
                 ServiceResponse.builder()
                         .success(false)
@@ -62,7 +65,7 @@ public class GlobalExceptionHandler {
         );
     }
 
-    private ResponseEntity<ServiceResponse<?>> buildErrorResponse(AuthErrorCode errorCode, BaseServiceException ex) {
+    private ResponseEntity<ServiceResponse<?>> buildErrorResponse(ErrorCode errorCode, BaseServiceException ex) {
         return new ResponseEntity<>(
                 ServiceResponse.builder()
                         .success(false)
@@ -80,7 +83,7 @@ public class GlobalExceptionHandler {
     // ---------------------------
     @ExceptionHandler(UsernameNotFoundException.class)
     public ResponseEntity<ServiceResponse<?>> handleUsernameNotFoundException(UsernameNotFoundException ex) {
-        return buildErrorResponse(AuthErrorCode.USER_NOT_FOUND);
+        return buildErrorResponse(SystemErrorCode.USER_NOT_FOUND);
     }
 
     @ExceptionHandler(BadCredentialsException.class)
@@ -147,7 +150,7 @@ public class GlobalExceptionHandler {
     // ---------------------------
     @ExceptionHandler(IllegalStateException.class)
     public ResponseEntity<ServiceResponse<?>> handleIllegalStateException(IllegalStateException ex) {
-        return buildErrorResponse(AuthErrorCode.SERVER_NOT_AVAILABLE);
+        return buildErrorResponse(SystemErrorCode.SERVER_NOT_AVAILABLE);
     }
 
     @ExceptionHandler(InternalServerException.class)
@@ -157,6 +160,6 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ServiceResponse<?>> handleUnknownException(Exception ex) {
-        return buildErrorResponse(AuthErrorCode.INTERNAL_ERROR);
+        return buildErrorResponse(SystemErrorCode.INTERNAL_ERROR);
     }
 }

--- a/auth-service/src/main/java/com/adventuretube/auth/service/AuthService.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/service/AuthService.java
@@ -3,6 +3,8 @@ package com.adventuretube.auth.service;
 import com.adventuretube.auth.config.google.GoogleTokenCredentialProperties;
 import com.adventuretube.auth.exceptions.*;
 import com.adventuretube.auth.exceptions.code.AuthErrorCode;
+import com.adventuretube.common.api.code.JwtErrorCode;
+import com.adventuretube.common.api.code.SystemErrorCode;
 import com.adventuretube.auth.model.mapper.MemberMapper;
 import com.adventuretube.auth.model.request.MemberLoginRequest;
 import com.adventuretube.auth.model.request.MemberRegisterRequest;
@@ -87,7 +89,7 @@ public class AuthService {
                 || body == null
                 || !body.isSuccess()) {
             logger.error("Failed to check email duplication: {}", response.getStatusCode());
-            throw new MemberServiceException(AuthErrorCode.INTERNAL_ERROR);
+            throw new MemberServiceException(SystemErrorCode.INTERNAL_ERROR);
         }
         // MARK:  Check Email duplication
         if (Boolean.TRUE.equals(body.getData())) {
@@ -105,7 +107,7 @@ public class AuthService {
                     new ParameterizedTypeReference<ServiceResponse<MemberDTO>>() {}
             );
             if (!registerMemberResponse.getStatusCode().is2xxSuccessful()) {
-                throw new MemberServiceException(AuthErrorCode.INTERNAL_ERROR);
+                throw new MemberServiceException(SystemErrorCode.INTERNAL_ERROR);
             }
 
            ServiceResponse<MemberDTO> registerMemberResponseBody = registerMemberResponse.getBody();
@@ -142,7 +144,7 @@ public class AuthService {
                     || !tokenStoredResponseBody.isSuccess()
                     || !Boolean.TRUE.equals(tokenStoredResponseBody.getData())) {
                 log.error("Token store failed: {}", tokenStoredResponseBody != null ? tokenStoredResponseBody.getMessage() : "no response body");
-                throw new TokenSaveFailedException(AuthErrorCode.TOKEN_SAVE_FAILED);
+                throw new TokenSaveFailedException(JwtErrorCode.TOKEN_SAVE_FAILED);
             }
             logger.info("Token stored successfully for user: {}", registeredUser.getEmail());
             // MARK:  return result
@@ -167,11 +169,11 @@ public class AuthService {
                  */
             } catch (Exception e) {
                 logger.error("Error parsing error response", e);
-                throw new MemberServiceException(AuthErrorCode.INTERNAL_ERROR);
+                throw new MemberServiceException(SystemErrorCode.INTERNAL_ERROR);
             }
         } catch (Exception ex) {
             logger.error("An unexpected error occurred during member registration", ex);
-            throw new MemberServiceException(AuthErrorCode.INTERNAL_ERROR);
+            throw new MemberServiceException(SystemErrorCode.INTERNAL_ERROR);
         }
 
     }
@@ -226,7 +228,7 @@ public class AuthService {
                 || !tokenStoredResponseBody.isSuccess()
                 || !Boolean.TRUE.equals(tokenStoredResponseBody.getData())) {
             log.error("Token store failed: {}", tokenStoredResponseBody != null ? tokenStoredResponseBody.getMessage() : "no response body");
-            throw new TokenSaveFailedException(AuthErrorCode.TOKEN_SAVE_FAILED);
+            throw new TokenSaveFailedException(JwtErrorCode.TOKEN_SAVE_FAILED);
         }
         logger.info("Token stored successfully for user: {}", email);
 
@@ -249,7 +251,7 @@ public class AuthService {
                 || deleteTokenResponseBody == null
                 || !deleteTokenResponseBody.isSuccess()
                 || !Boolean.TRUE.equals(deleteTokenResponseBody.getData())) {
-            throw new TokenDeletionException(AuthErrorCode.TOKEN_DELETION_FAILED);
+            throw new TokenDeletionException(JwtErrorCode.TOKEN_DELETION_FAILED);
         }
 
         logger.info("Token revoked successfully for token: {}", token);
@@ -288,7 +290,7 @@ public class AuthService {
                 || findTokenResponseBody == null
                 || !findTokenResponseBody.isSuccess()
                 || !Boolean.TRUE.equals(findTokenResponseBody.getData())) {
-            throw new TokenNotFoundException(AuthErrorCode.TOKEN_NOT_FOUND);
+            throw new TokenNotFoundException(JwtErrorCode.TOKEN_NOT_FOUND);
         }
 
 
@@ -322,7 +324,7 @@ public class AuthService {
                 || !tokenStoredResponseBody.isSuccess()
                 || !Boolean.TRUE.equals(tokenStoredResponseBody.getData())) {
             log.error("Token store failed: {}", tokenStoredResponseBody != null ? tokenStoredResponseBody.getMessage() : "no response body");
-            throw new TokenSaveFailedException(AuthErrorCode.TOKEN_SAVE_FAILED);
+            throw new TokenSaveFailedException(JwtErrorCode.TOKEN_SAVE_FAILED);
         }
 
         return new MemberRegisterResponse(null, accessToken, refreshToken);

--- a/auth-service/src/main/java/com/adventuretube/auth/service/CustomUserDetailService.java
+++ b/auth-service/src/main/java/com/adventuretube/auth/service/CustomUserDetailService.java
@@ -1,7 +1,7 @@
 package com.adventuretube.auth.service;
 
-import com.adventuretube.auth.exceptions.code.AuthErrorCode;
 import com.adventuretube.auth.exceptions.UserNotFoundException;
+import com.adventuretube.common.api.code.SystemErrorCode;
 import com.adventuretube.auth.model.dto.member.MemberDTO;
 import com.adventuretube.common.api.response.ServiceResponse;
 import lombok.AllArgsConstructor;
@@ -41,7 +41,7 @@ public class CustomUserDetailService implements UserDetailsService {
 
             userFoundByEmail = response.getBody().getData();
             if (userFoundByEmail == null) {
-                throw new UserNotFoundException(AuthErrorCode.USER_NOT_FOUND);
+                throw new UserNotFoundException(SystemErrorCode.USER_NOT_FOUND);
             }
             // Check that userFoundByEmail has the necessary properties
             if (userFoundByEmail.getEmail() == null || userFoundByEmail.getPassword() == null) {

--- a/common-api/src/main/java/com/adventuretube/common/api/code/ErrorCode.java
+++ b/common-api/src/main/java/com/adventuretube/common/api/code/ErrorCode.java
@@ -1,0 +1,8 @@
+package com.adventuretube.common.api.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    String getMessage();
+    HttpStatus getHttpStatus();
+}

--- a/common-api/src/main/java/com/adventuretube/common/api/code/JwtErrorCode.java
+++ b/common-api/src/main/java/com/adventuretube/common/api/code/JwtErrorCode.java
@@ -1,0 +1,20 @@
+package com.adventuretube.common.api.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+    TOKEN_DELETION_FAILED("Failed to delete token during logout", HttpStatus.INTERNAL_SERVER_ERROR),
+    TOKEN_SAVE_FAILED("Failed to save token during login", HttpStatus.INTERNAL_SERVER_ERROR),
+    TOKEN_NOT_FOUND("Token not found", HttpStatus.NOT_FOUND),
+    TOKEN_NOT_EXIST("Token is not exist", HttpStatus.UNAUTHORIZED),
+    TOKEN_INVALID("Invalid JWT signature", HttpStatus.UNAUTHORIZED),
+    TOKEN_MALFORMED("Malformed JWT token", HttpStatus.UNAUTHORIZED),
+    TOKEN_EXPIRED("Token expired", HttpStatus.UNAUTHORIZED);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/common-api/src/main/java/com/adventuretube/common/api/code/SystemErrorCode.java
+++ b/common-api/src/main/java/com/adventuretube/common/api/code/SystemErrorCode.java
@@ -1,0 +1,18 @@
+package com.adventuretube.common.api.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SystemErrorCode implements ErrorCode {
+    SERVER_NOT_AVAILABLE("Server is not available", HttpStatus.INTERNAL_SERVER_ERROR),
+    INTERNAL_ERROR("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR),
+    VALIDATION_FAILED("Validation failed", HttpStatus.BAD_REQUEST),
+    USER_NOT_FOUND("User not found", HttpStatus.NOT_FOUND),
+    UNKNOWN_EXCEPTION("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
+
+    private final String message;
+    private final HttpStatus httpStatus;
+}

--- a/gateway-service/src/main/java/com/adventuretube/apigateway/exception/GlobalExceptionHandler.java
+++ b/gateway-service/src/main/java/com/adventuretube/apigateway/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.adventuretube.apigateway.exception;
 
+import com.adventuretube.common.api.code.JwtErrorCode;
+import com.adventuretube.common.api.code.SystemErrorCode;
 import com.adventuretube.common.api.response.ServiceResponse;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
@@ -18,11 +20,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(JwtTokenNotExistException.class)
     public ResponseEntity<ServiceResponse<Void>> handleJwtTokenNotExistException(JwtTokenNotExistException ex) {
         return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
+                .status(JwtErrorCode.TOKEN_NOT_EXIST.getHttpStatus())
                 .body(ServiceResponse.<Void>builder()
                         .success(false)
-                        .message(ex.getMessage())
-                        .errorCode("JWT_TOKEN_NOT_EXIST : gateway-service")
+                        .message(JwtErrorCode.TOKEN_NOT_EXIST.getMessage() + ": gateway-service")
+                        .errorCode(JwtErrorCode.TOKEN_NOT_EXIST.name())
                         .data(null)
                         .timestamp(java.time.LocalDateTime.now())
                         .build());
@@ -31,11 +33,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(SignatureException.class)
     public ResponseEntity<ServiceResponse<Void>> handleSignatureException(SignatureException ex) {
         return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
+                .status(JwtErrorCode.TOKEN_INVALID.getHttpStatus())
                 .body(ServiceResponse.<Void>builder()
                         .success(false)
-                        .message("Invalid JWT signature: gateway-service")
-                        .errorCode(ex.getMessage())
+                        .message(JwtErrorCode.TOKEN_INVALID.getMessage() + ": gateway-service")
+                        .errorCode(JwtErrorCode.TOKEN_INVALID.name())
                         .data(null)
                         .timestamp(java.time.LocalDateTime.now())
                         .build());
@@ -44,11 +46,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MalformedJwtException.class)
     public ResponseEntity<ServiceResponse<Void>> handleMalformedJwtException(MalformedJwtException ex) {
         return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
+                .status(JwtErrorCode.TOKEN_MALFORMED.getHttpStatus())
                 .body(ServiceResponse.<Void>builder()
                         .success(false)
-                        .message("Malformed JWT token: gateway-service")
-                        .errorCode(ex.getMessage())
+                        .message(JwtErrorCode.TOKEN_MALFORMED.getMessage() + ": gateway-service")
+                        .errorCode(JwtErrorCode.TOKEN_MALFORMED.name())
                         .data(null)
                         .timestamp(java.time.LocalDateTime.now())
                         .build());
@@ -57,11 +59,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ExpiredJwtException.class)
     public ResponseEntity<ServiceResponse<Void>> handleExpiredJwtException(ExpiredJwtException ex) {
         return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
+                .status(JwtErrorCode.TOKEN_EXPIRED.getHttpStatus())
                 .body(ServiceResponse.<Void>builder()
                         .success(false)
-                        .message("Expired JWT token: gateway-service")
-                        .errorCode(ex.getMessage())
+                        .message(JwtErrorCode.TOKEN_EXPIRED.getMessage() + ": gateway-service")
+                        .errorCode(JwtErrorCode.TOKEN_EXPIRED.name())
                         .data(null)
                         .timestamp(java.time.LocalDateTime.now())
                         .build());
@@ -70,11 +72,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ServiceResponse<Void>> handleUnknownException(Exception ex) {
         return ResponseEntity
-                .status(INTERNAL_SERVER_ERROR)
+                .status(SystemErrorCode.INTERNAL_ERROR.getHttpStatus())
                 .body(ServiceResponse.<Void>builder()
                         .success(false)
-                        .message("Internal Server Error: gateway-service")
-                        .errorCode(ex.getMessage())
+                        .message(SystemErrorCode.INTERNAL_ERROR.getMessage() + ": gateway-service")
+                        .errorCode(SystemErrorCode.INTERNAL_ERROR.name())
                         .data(null)
                         .timestamp(java.time.LocalDateTime.now())
                         .build());

--- a/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/EnvFileException.java
+++ b/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/EnvFileException.java
@@ -1,12 +1,11 @@
 package com.adventuretube.geospatial.exceptions;
 
-import com.adventuretube.geospatial.exceptions.code.GeoErrorCode;
 import com.adventuretube.geospatial.exceptions.base.BaseServiceException;
-import com.adventuretube.geospatial.exceptions.code.GeoErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class EnvFileException extends BaseServiceException {
 
-    public EnvFileException(GeoErrorCode errorCode) {
+    public EnvFileException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/GlobalExceptionHandler.java
+++ b/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.adventuretube.geospatial.exceptions;
 
+import com.adventuretube.common.api.code.SystemErrorCode;
 import com.adventuretube.common.api.response.ServiceResponse;
-import com.adventuretube.geospatial.exceptions.code.GeoErrorCode;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -17,8 +17,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ServiceResponse<?>> handleUnknownException(Exception ex) {
         ServiceResponse<?> response = ServiceResponse.builder()
                 .success(false)
-                .message(GeoErrorCode.UNKNOWN_EXCEPTION.getMessage() + ": geospatial-service")
-                .errorCode(GeoErrorCode.UNKNOWN_EXCEPTION.name())
+                .message(SystemErrorCode.UNKNOWN_EXCEPTION.getMessage() + ": geospatial-service")
+                .errorCode(SystemErrorCode.UNKNOWN_EXCEPTION.name())
                 .data(null)
                 .timestamp(java.time.LocalDateTime.now())
                 .build();
@@ -30,8 +30,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ServiceResponse<?>> handleUsernameNotFoundException(UsernameNotFoundException ex) {
         ServiceResponse<?> response = ServiceResponse.builder()
                 .success(false)
-                .message(GeoErrorCode.USER_NOT_FOUND.getMessage() + ": geospatial-service")
-                .errorCode(GeoErrorCode.USER_NOT_FOUND.name())
+                .message(SystemErrorCode.USER_NOT_FOUND.getMessage() + ": geospatial-service")
+                .errorCode(SystemErrorCode.USER_NOT_FOUND.name())
                 .data(null)
                 .timestamp(java.time.LocalDateTime.now())
                 .build();

--- a/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/base/BaseServiceException.java
+++ b/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/base/BaseServiceException.java
@@ -1,12 +1,12 @@
 package com.adventuretube.geospatial.exceptions.base;
 
-import com.adventuretube.geospatial.exceptions.code.GeoErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public abstract class BaseServiceException extends RuntimeException {
-    private final GeoErrorCode errorCode;
+    private final ErrorCode errorCode;
     private final String origin;
 
-    public BaseServiceException(GeoErrorCode errorCode) {
+    public BaseServiceException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
 
@@ -17,7 +17,7 @@ public abstract class BaseServiceException extends RuntimeException {
                 : "UnknownOrigin";
     }
 
-    public GeoErrorCode getErrorCode() {
+    public ErrorCode getErrorCode() {
         return errorCode;
     }
 

--- a/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/code/GeoErrorCode.java
+++ b/geospatial-service/src/main/java/com/adventuretube/geospatial/exceptions/code/GeoErrorCode.java
@@ -1,16 +1,12 @@
 package com.adventuretube.geospatial.exceptions.code;
 
+import com.adventuretube.common.api.code.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum GeoErrorCode {
-    ENV_FILE_NOT_FOUND("ENV_FILE_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR),
-
-    USER_NOT_FOUND("User not found", HttpStatus.NOT_FOUND),
-
-    //UNKNOWN EXCEPTION
-    UNKNOWN_EXCEPTION("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
+public enum GeoErrorCode implements ErrorCode {
+    ENV_FILE_NOT_FOUND("ENV_FILE_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR);
     private final String message;
     private final HttpStatus httpStatus;
 

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/DuplicateException.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/DuplicateException.java
@@ -1,11 +1,11 @@
 package com.adventuretube.member.exceptions;
 
 import com.adventuretube.member.exceptions.base.BaseServiceException;
-import com.adventuretube.member.exceptions.code.MemberErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class DuplicateException extends BaseServiceException {
 
-  public DuplicateException(MemberErrorCode errorCode) {
+  public DuplicateException(ErrorCode errorCode) {
     super(errorCode);
   }
 }

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/EnvFileException.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/EnvFileException.java
@@ -1,11 +1,11 @@
 package com.adventuretube.member.exceptions;
 
 import com.adventuretube.member.exceptions.base.BaseServiceException;
-import com.adventuretube.member.exceptions.code.MemberErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public class EnvFileException  extends BaseServiceException {
 
-    public EnvFileException(MemberErrorCode errorCode) {
+    public EnvFileException(ErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/GlobalExceptionHandler.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.adventuretube.member.exceptions;
 
 
+import com.adventuretube.common.api.code.ErrorCode;
+import com.adventuretube.common.api.code.SystemErrorCode;
 import com.adventuretube.common.api.response.ServiceResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -15,15 +17,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicateException.class)
     public ResponseEntity<ServiceResponse<Void>> handleDuplicationException(DuplicateException ex) {
 
-        ServiceResponse restAPIErrorResponse = ServiceResponse.builder()
+        ErrorCode code = ex.getErrorCode();
+        ServiceResponse<Void> restAPIErrorResponse = ServiceResponse.<Void>builder()
                 .success(false)
-                .message("User already exists with the provided email : member-service")
-                .errorCode("DUPLICATE_ERROR")
+                .message(code.getMessage() + " : member-service")
+                .errorCode(code.name())
                 .data(null)
                 .timestamp(java.time.LocalDateTime.now())
                 .build();
 
-        return new ResponseEntity<ServiceResponse<Void>>(restAPIErrorResponse,HttpStatus.CONFLICT);
+        return new ResponseEntity<>(restAPIErrorResponse, code.getHttpStatus());
     }
 
 
@@ -32,12 +35,12 @@ public class GlobalExceptionHandler {
 
         ServiceResponse restAPIErrorResponse = ServiceResponse.builder()
                 .success(false)
-                .message("Internal Server Error : member-service")
-                .errorCode("UNKNOWN_ERROR")
+                .message(SystemErrorCode.UNKNOWN_EXCEPTION.getMessage() + " : member-service")
+                .errorCode(SystemErrorCode.UNKNOWN_EXCEPTION.name())
                 .data(null)
                 .timestamp(java.time.LocalDateTime.now())
                 .build();
 
-            return new ResponseEntity<>(restAPIErrorResponse, INTERNAL_SERVER_ERROR);
+        return new ResponseEntity<>(restAPIErrorResponse, INTERNAL_SERVER_ERROR);
     }
 }

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/base/BaseServiceException.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/base/BaseServiceException.java
@@ -1,12 +1,12 @@
 package com.adventuretube.member.exceptions.base;
 
-import com.adventuretube.member.exceptions.code.MemberErrorCode;
+import com.adventuretube.common.api.code.ErrorCode;
 
 public abstract class BaseServiceException extends RuntimeException {
-    private final MemberErrorCode errorCode;
+    private final ErrorCode errorCode;
     private final String origin;
 
-    public BaseServiceException(MemberErrorCode errorCode) {
+    public BaseServiceException(ErrorCode errorCode) {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
 
@@ -17,7 +17,7 @@ public abstract class BaseServiceException extends RuntimeException {
                 : "UnknownOrigin";
     }
 
-    public MemberErrorCode getErrorCode() {
+    public ErrorCode getErrorCode() {
         return errorCode;
     }
 

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/code/MemberErrorCode.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/code/MemberErrorCode.java
@@ -1,14 +1,12 @@
 package com.adventuretube.member.exceptions.code;
 
+import com.adventuretube.common.api.code.ErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum MemberErrorCode {
-    ENV_FILE_NOT_FOUND("ENV_FILE_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR),
-
-    //UNKNOWN EXCEPTION
-    UNKNOWN_EXCEPTION("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
+public enum MemberErrorCode implements ErrorCode {
+    ENV_FILE_NOT_FOUND("ENV_FILE_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR);
 
 
     private final String message;


### PR DESCRIPTION
## Summary
- add `ErrorCode` interface with `SystemErrorCode` and `JwtErrorCode`
- remove duplicated values from `AuthErrorCode`, `MemberErrorCode`, and `GeoErrorCode`
- update service exceptions to accept the shared `ErrorCode` interface
- adjust services and global handlers to use the new enums

## Testing
- `./mvnw -q -DskipTests package` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684aeaed0e30832c875115678a91b8c8