### PR TITLE
Fix controller exception handling

### DIFF
--- a/member-service/src/main/java/com/adventuretube/member/controller/MemberController.java
+++ b/member-service/src/main/java/com/adventuretube/member/controller/MemberController.java
@@ -27,28 +27,15 @@ public class MemberController {
     public ResponseEntity<ServiceResponse<MemberDTO>> registerMember(@RequestBody MemberDTO memberDTO) {
         log.info("new member registration {}", memberDTO);
         Member newMember = memberMapper.memberDTOtoMember(memberDTO);
-        try {
-            Member registeredMember = memberService.registerMember(newMember);
-            memberDTO.setId(registeredMember.getId());
+        Member registeredMember = memberService.registerMember(newMember);
+        memberDTO.setId(registeredMember.getId());
 
-            return ResponseEntity.ok(ServiceResponse.<MemberDTO>builder()
-                    .success(true)
-                    .message("Member registered successfully")
-                    .data(memberDTO)
-                    .timestamp(java.time.LocalDateTime.now())
-                    .build());
-
-        } catch (Exception e) {
-            log.error("Error occurred while registering member", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ServiceResponse.<MemberDTO>builder()
-                            .success(false)
-                            .message("Failed to register member")
-                            .errorCode("MEMBER_REGISTRATION_FAILED")
-                            .data(null)
-                            .timestamp(java.time.LocalDateTime.now())
-                            .build());
-        }
+        return ResponseEntity.ok(ServiceResponse.<MemberDTO>builder()
+                .success(true)
+                .message("Member registered successfully")
+                .data(memberDTO)
+                .timestamp(java.time.LocalDateTime.now())
+                .build());
     }
 
     @PostMapping("emailDuplicationCheck")
@@ -112,30 +99,19 @@ public class MemberController {
     @PostMapping("deleteUser")
     public ResponseEntity<ServiceResponse<Boolean>> deleteUser(@RequestBody String email) {
         log.info("Deleting user with email: {}", email);
-        try {
-            boolean isDeleted = memberService.deleteUser(email);
-            if (isDeleted) {
-                return ResponseEntity.ok(ServiceResponse.<Boolean>builder()
-                        .success(true)
-                        .message("User deleted successfully")
-                        .data(true)
-                        .timestamp(java.time.LocalDateTime.now())
-                        .build());
-            } else {
-                return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ServiceResponse.<Boolean>builder()
-                        .success(false)
-                        .message("User not found")
-                        .data(false)
-                        .timestamp(java.time.LocalDateTime.now())
-                        .build());
-            }
-        } catch (Exception e) {
-            log.error("Error occurred while deleting user", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(ServiceResponse.<Boolean>builder()
+        boolean isDeleted = memberService.deleteUser(email);
+        if (isDeleted) {
+            return ResponseEntity.ok(ServiceResponse.<Boolean>builder()
+                    .success(true)
+                    .message("User deleted successfully")
+                    .data(true)
+                    .timestamp(java.time.LocalDateTime.now())
+                    .build());
+        } else {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ServiceResponse.<Boolean>builder()
                     .success(false)
-                    .message("Error occurred while deleting user")
-                    .errorCode("DELETE_USER_ERROR")
-                    .data(null)
+                    .message("User not found")
+                    .data(false)
                     .timestamp(java.time.LocalDateTime.now())
                     .build());
         }

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/MemberNotFoundException.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/MemberNotFoundException.java
@@ -1,0 +1,10 @@
+package com.adventuretube.member.exceptions;
+
+import com.adventuretube.member.exceptions.base.BaseServiceException;
+import com.adventuretube.member.exceptions.code.MemberErrorCode;
+
+public class MemberNotFoundException extends BaseServiceException {
+    public MemberNotFoundException(MemberErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/member-service/src/main/java/com/adventuretube/member/exceptions/code/MemberErrorCode.java
+++ b/member-service/src/main/java/com/adventuretube/member/exceptions/code/MemberErrorCode.java
@@ -7,6 +7,9 @@ import org.springframework.http.HttpStatus;
 public enum MemberErrorCode {
     ENV_FILE_NOT_FOUND("ENV_FILE_NOT_FOUND", HttpStatus.INTERNAL_SERVER_ERROR),
 
+    USER_EMAIL_DUPLICATE("User already exists with the provided email", HttpStatus.CONFLICT),
+    USER_NOT_FOUND("User not found", HttpStatus.NOT_FOUND),
+
     //UNKNOWN EXCEPTION
     UNKNOWN_EXCEPTION("Unknown error", HttpStatus.INTERNAL_SERVER_ERROR);
 


### PR DESCRIPTION
## Summary
- rely on service layer for exceptions in member controller
- have service raise DuplicateException or MemberNotFoundException
- centralize member-service exception responses

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_684eaa84879c832c864aad5ea0c42184